### PR TITLE
Remove "no html" statement for bookmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ Add names for the categories you wish to define and add the bookmarks for each c
 
 Please note:
 
- - No `http://` in the URL
  - No `,` at the end of the last bookmark in a category and at the end of the last category
 
 


### PR DESCRIPTION
Hi, since there are no "issues" in this repository let me start a discussion this way.

For the "apps" section there is the statement that one should not use http/https when specifying entries. What is the motivation this. Does this use the assumption that when the app itself is accessed over https all linked entries are as well (and vice versa)?

Edit: After looking at the code a bit closer it just prefixes all urls with https, regardless how the site was accessed.