### PR TITLE
remove leading https:// for url, remove address under apps

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,8 +86,8 @@
                             <span class="iconify icon" data-icon="mdi-{{icon}}"></span>
                         </div>
                         <div class="apps_text">
-                            <a href="https://{{url}}">{{name}}</a>
-                            <span>{{url}}</span>
+                            <a href="{{url}}">{{name}}</a>
+			    <!-- <span>{{url}}</span> -->
                         </div>
                     </div>
                 {{/apps}}                         


### PR DESCRIPTION
The current way this is set up is that it prepends an ```https://``` to the url but this shouldn't be needed. Users should be allowed to enter the full URL of their choosing.

Also, for long URLs in the app section just remove the visible address. If it is a long address it becomes graphiclly ugly and unreadable.