### PR TITLE
[Deprecated] Make links open new tabs

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -29,9 +29,18 @@ function greet() {
   }
 }
 
+function makeSafeNewTabs() {
+  var links = document.links;
+  for (var i = 0; i < links.length; i++) {
+    links[i].target = "_blank";
+    links[i].rel = "noopener noreferrer";
+  } 
+}
+
 function loadFunctions() {
   date();  
   greet();
+  makeSafeNewTabs()
 }
 
 


### PR DESCRIPTION
Causes links to be opened in new tabs, allowing the page to be used as a hub more easily. The rel portion is to prevent possible exploits. See: https://www.freecodecamp.org/news/how-to-use-html-to-open-link-in-new-tab