### PR TITLE
Make app links use HTTP by default and define default search engine in variable

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -120,7 +120,7 @@ function search(text) {
         else
             window.location = "https://" + text;
     } else {
-        window.location = "https://www.google.com/search?q=" + text;
+        window.location = sengine + text;
     }
 }
 

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -96,7 +96,6 @@ function search(text) {
                 case "g":
                     window.location = "https://www.google.com/?q=" + subtext;
                     break;
-
             }
         } else {
             var option = text.substr(1);

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,5 +1,6 @@
 var sindex = 0;
 var cycle = false;
+var sengine = "https://www.google.com/?q="; // Default search engine
 
 function start() {
     var query = getParameterByName('q');
@@ -92,6 +93,10 @@ function search(text) {
                 case "y":
                     window.location = "https://www.youtube.com/results?search_query=" + subtext;
                     break;
+                case "g":
+                    window.location = "https://www.google.com/?q=" + subtext;
+                    break;
+
             }
         } else {
             var option = text.substr(1);

--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
                             <span class="iconify icon" data-icon="mdi-{{icon}}"></span>
                         </div>
                         <div class="apps_text">
-                            <a href="https://{{url}}" {{#if target}}target="{{target}}"{{/if}} >{{name}}</a>
+                            <a href="http://{{url}}" {{#if target}}target="{{target}}"{{/if}} >{{name}}</a>
                             <span id="app-address">{{url}}</span>
                         </div>
                     </div>


### PR DESCRIPTION
Hi there,
I'm proposing the following changes:
 - Change the default app links protocol from HTTPS to HTTP. This change assumes that at least in some instances, SUI will be used in a local network/VPN environment where not all services are reached via domain names and have certificates. Using HTTP allows the user to point to 192.168.1.1, and thanks to modern browsers and HSTS, HTTPS will be used where it's supported.
 - Define the default search engine in a variable so that it can be changed. I have set this to Google to preserve the current behavior, and added a /g case to make it available if changed.
 
All the best.  