### PR TITLE
auto pulling from git repo

### DIFF
--- a/DockerfilePullFromGit
+++ b/DockerfilePullFromGit
@@ -1,0 +1,10 @@
+FROM ubuntu:latest
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install nginx git cron nano
+
+COPY install.sh /tmp/
+
+EXPOSE 80
+
+# execute install, start cron and nginx
+CMD chmod +x /tmp/install.sh && /tmp/install.sh && cron && nginx

--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ To run at a different port open edit docker-compose.yml:
     ports:
           - 4000:80
 
+#### Install pull from git variant:
+
+ - refreshs source code every 5 minutes from master branch you provided - convenience feature for lacy devs
+ - `git clone` this repository
+ - build image `docker build -f DockerfilePullFromGit -t sui:latest .`
+ - run image with `docker run -e GITURL='https://x:ghp_x@github.com/jeroenpardon/sui.git' -p 8081:80 sui:latest`
+ - can be run also with a private repository by setting username:api-key@ in the url (see above example). Otherwise remove this part of the url.
+ 
+
+
 ### Customization
 
 #### Changing color themes

--- a/gitpull.sh
+++ b/gitpull.sh
@@ -1,2 +1,2 @@
 cd /var/www/html
-git -C repo pull
+git pull

--- a/gitpull.sh
+++ b/gitpull.sh
@@ -1,0 +1,2 @@
+cd /var/www/html
+git -C repo pull

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,23 @@
+cd /var/www/html
+git clone $GITURL sui
+mv sui/* .
+rm -rf sui
+echo "pulled update"
+
+# Copy hello-cron file to the cron.d directory
+cp sui-cron /etc/cron.d/sui-cron
+
+# Give execution rights on the cron job
+chmod 0644 /etc/cron.d/sui-cron
+
+# set pull script permissions
+chmod +x gitpull.sh
+
+# Apply cron job
+crontab /etc/cron.d/sui-cron
+
+# Create the log file to be able to run tail
+touch /var/log/cron.log
+
+# configure nginx
+echo "daemon off;" >> /etc/nginx/nginx.conf

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,6 @@
 cd /var/www/html
 git clone $GITURL sui
+shopt -s dotglob
 mv sui/* .
 rm -rf sui
 echo "pulled update"

--- a/sui-cron
+++ b/sui-cron
@@ -1,0 +1,2 @@
+*/1 * * * * /var/www/html/gitpull.sh >> /var/log/cron.log 2>&1
+# An empty line is required at the end of this file for a valid cron file.


### PR DESCRIPTION
added a convenience feature to pull the latest code from the git repo periodically to prevent a re-deployment of the docker image. It kind of breaks the container concept but for this use case it is totally fine.